### PR TITLE
fix(sec): upgrade com.alibaba:fastjson to 1.2.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.24</version>
+            <version>1.2.83</version>
         </dependency>
 	    
 	 <dependency>


### PR DESCRIPTION
Upgrade com.alibaba:fastjson from 1.2.24 to 1.2.83 for vulnerability fix: 
- [CVE-2022-25845](https://www.oscs1024.com/hd/CVE-2022-25845)
- [MPS-2019-28847](https://www.oscs1024.com/hd/MPS-2019-28847)
- [MPS-2019-28848](https://www.oscs1024.com/hd/MPS-2019-28848)
- [MPS-2020-39708](https://www.oscs1024.com/hd/MPS-2020-39708)
- [MPS-2020-40828](https://www.oscs1024.com/hd/MPS-2020-40828)
- [CVE-2017-18349](https://www.oscs1024.com/hd/CVE-2017-18349)
