### PR TITLE
fix(sec): upgrade com.alibaba:fastjson to 1.2.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.24</version>
+            <version>1.2.83</version>
         </dependency>
 	    
 	 <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.alibaba:fastjson 1.2.24
- [CVE-2022-25845](https://www.oscs1024.com/hd/CVE-2022-25845)




### What did I do？
Upgrade com.alibaba:fastjson from 1.2.24 to 1.2.83 for vulnerability fix



### What did you expect to happen？
Ideally, no insecure libs should be used.





### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS