### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.12.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	 <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.9-SNAPSHOT</version>
+            <version>2.12.6.1</version>
          </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.9.10.9-SNAPSHOT
- [CVE-2020-36518](https://www.oscs1024.com/hd/CVE-2020-36518)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.9.10.9-SNAPSHOT to 2.12.6.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS